### PR TITLE
require node 4 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "dependencies": {
     "yamljs": "^0.2.8"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
This will prevent confusion for any users of node <4, as the `npm install` step will fail with a message about the node version.