### PR TITLE
test the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "A collection of apps built on Electron",
   "main": "index.json",
   "scripts": {
-    "install": "node build.js > index.json",
-    "test": "mocha",
+    "build": "node build.js > index.json",
+    "install": "npm run build",
+    "test": "npm run build && mocha",
     "wizard": "node wizard.js"
   },
   "repository": "https://github.com/electron/electron-apps",

--- a/test/build.js
+++ b/test/build.js
@@ -1,0 +1,30 @@
+const fs = require('fs')
+const path = require('path')
+const apps = require('..')
+const expect = require('chai').expect
+
+describe('index.json build artifact', () => {
+
+  it('is an array', () => {
+    expect(apps).to.be.an('array')
+  })
+
+  it('has the same number of apps as the apps directory', () => {
+    const slugs = fs.readdirSync(path.join(__dirname, '../apps'))
+      .filter(filename => {
+        return fs.statSync(path.join(__dirname, `../apps/${filename}`)).isDirectory()
+      })
+
+    expect(apps.length).to.be.above(100)
+    expect(apps.length).to.equal(slugs.length)
+  })
+
+  it('sets a `slug` property on every app', () => {
+    expect(apps.every(app => app.slug.length > 0)).to.equal(true)
+  })
+
+  it('sets a .png `icon` property on every app', () => {
+    expect(apps.every(app => !!app.icon.match(/\.png$/))).to.equal(true)
+  })
+
+})

--- a/test/data.js
+++ b/test/data.js
@@ -7,19 +7,19 @@ const isUrl = require('is-url')
 const cleanDeep = require('clean-deep')
 const imageSize = require('image-size')
 const slugg = require('slugg')
-const slugs = fs.readdirSync(path.join(__dirname, '/apps'))
+const slugs = fs.readdirSync(path.join(__dirname, '../apps'))
   .filter(filename => {
-    return fs.statSync(path.join(__dirname, `/apps/${filename}`)).isDirectory()
+    return fs.statSync(path.join(__dirname, `../apps/${filename}`)).isDirectory()
   })
 
-describe('electron-apps', () => {
+describe('app data', () => {
   it('includes lots of apps', () => {
     expect(slugs.length).to.be.above(200)
   })
 
   slugs.forEach(slug => {
     describe(slug, () => {
-      const basedir = path.join(__dirname, `/apps/${slug}`)
+      const basedir = path.join(__dirname, `../apps/${slug}`)
       const yamlFile = `${slug}.yml`
       const yamlPath = path.join(basedir, yamlFile)
       const iconPath = path.join(basedir, `${slug}-icon.png`)


### PR DESCRIPTION
The existing test verify the structure and content of the metadata and icon files in the `apps` directory. 

These new tests verify that the `require`able `index.json` file produced by the build script is intact and has all the expected metadata.