### PR TITLE
skip icon dimensions tests if file doesn't exist

### DIFF
--- a/test/data.js
+++ b/test/data.js
@@ -58,20 +58,22 @@ describe('app data', () => {
 
       describe('icon', () => {
         it(`exists as ${slug}-icon.png`, () => {
-          expect(pathExists(iconPath)).to.equal(true, 'no icon file found')
+          expect(pathExists(iconPath)).to.equal(true, `${slug}-icon.png not found`)
         })
 
-        it('is a square', () => {
+        it('is a square', function () {
+          if (!pathExists(iconPath)) return this.skip()
+
           const dimensions = imageSize(iconPath)
           expect(dimensions.width).to.be.a('number')
           expect(dimensions.width).to.equal(dimensions.height)
         })
 
-        it('is at least 100px x 100px', () => {
-          if (pathExists(iconPath)) {
-            const dimensions = imageSize(iconPath)
-            expect(dimensions.width).to.be.above(99)
-          }
+        it('is at least 100px x 100px', function () {
+          if (!pathExists(iconPath)) return this.skip()
+
+          const dimensions = imageSize(iconPath)
+          expect(dimensions.width).to.be.above(99)
         })
       })
     })


### PR DESCRIPTION
## Problem

Users sometimes include an icon file that has the proper dimensions, but is not properly named. The test suite was showing errors like "icon must be a square" not because the icon wasn't sqaure, but because the target filename didn't exist. Example: https://github.com/electron/electron-apps/pull/46

<img width="567" alt="screen shot 2016-12-31 at 6 46 06 am" src="https://cloud.githubusercontent.com/assets/2289/21578003/d6e21852-cf24-11e6-8bd8-8275c47b3f11.png">

## Solution

If the icon file is not found, skip these tests using mocha's built-in `this.skip()` feature.

cc @MedZed