### PR TITLE
Resize app icons at install time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 yarn.lock
 index.json
 node_modules
+*-32.png
+*-64.png
+*-128.png

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+env:
+  CXX=g++-4.8
 language: node_js
 node_js:
   - "4"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of apps built on Electron",
   "main": "index.json",
   "scripts": {
-    "build": "node build.js > index.json",
+    "build": "node script/resize.js && node script/build.js > index.json",
     "install": "npm run build",
     "test": "npm run build && mocha",
     "wizard": "node wizard.js"
@@ -28,6 +28,8 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "path-exists": "^3.0.0",
+    "recursive-readdir-sync": "^1.0.6",
+    "sharp": "^0.17.0",
     "slugg": "^1.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "path-exists": "^3.0.0",
-    "recursive-readdir-sync": "^1.0.6",
-    "sharp": "^0.17.0",
     "slugg": "^1.1.0"
   },
   "dependencies": {
+    "recursive-readdir-sync": "^1.0.6",
+    "sharp": "^0.17.0",
     "yamljs": "^0.2.8"
   },
   "engines": {

--- a/script/build.js
+++ b/script/build.js
@@ -3,22 +3,24 @@ const path = require('path')
 const yaml = require('yamljs')
 const apps = []
 
-fs.readdirSync(path.join(__dirname, 'apps'))
+fs.readdirSync(path.join(__dirname, '../apps'))
 .filter(filename => {
-  return fs.statSync(path.join(__dirname, `/apps/${filename}`)).isDirectory()
+  return fs.statSync(path.join(__dirname, `../apps/${filename}`)).isDirectory()
 })
 .forEach(slug => {
-  const yamlFile = path.join(__dirname, `apps/${slug}/${slug}.yml`)
+  const yamlFile = path.join(__dirname, `../apps/${slug}/${slug}.yml`)
   const app = Object.assign(
     {slug: slug},
     yaml.load(yamlFile),
     {icon: `${slug}-icon.png`},
-    {icon50: `${slug}-icon-50.png`}
+    {icon32: `${slug}-icon-32.png`},
+    {icon64: `${slug}-icon-64.png`},
+    {icon128: `${slug}-icon-128.png`}
   )
   apps.push(app)
 })
 
 fs.writeFileSync(
-  path.join(__dirname, 'index.json'),
+  path.join(__dirname, '../index.json'),
   JSON.stringify(apps, null, 2)
 )

--- a/script/build.js
+++ b/script/build.js
@@ -12,7 +12,8 @@ fs.readdirSync(path.join(__dirname, 'apps'))
   const app = Object.assign(
     {slug: slug},
     yaml.load(yamlFile),
-    {icon: `${slug}-icon.png`}
+    {icon: `${slug}-icon.png`},
+    {icon50: `${slug}-icon-50.png`}
   )
   apps.push(app)
 })

--- a/script/resize.js
+++ b/script/resize.js
@@ -1,0 +1,35 @@
+const sharp = require('sharp')
+const path = require('path')
+const fs = require('fs')
+const recursiveReadSync = require('recursive-readdir-sync')
+const icons = recursiveReadSync(path.join(__dirname, '../apps'))
+  .filter(file => file.match(/icon\.png/))
+
+console.log(`Resizing ${icons.length} icons...`)
+
+function resize (icon, size) {
+  const newFile = icon.replace('.png', `-${size}.png`)
+  return sharp(fs.readFileSync(icon))
+    .resize(size, size)
+    .max()
+    .toFormat('png')
+    .toFile(newFile)
+    .then(() => {
+      console.log(newFile)
+    })
+}
+
+const resizes = icons.map(icon => resize(icon, 32))
+  .concat(icons.map(icon => resize(icon, 64)))
+  .concat(icons.map(icon => resize(icon, 128)))
+
+Promise.all(resizes)
+  .then(function (results) {
+    console.log(`Done resizing ${icons.length} icons`)
+    process.exit()
+  })
+  .catch(function (err) {
+    console.error('Problem resizing icons')
+    console.error(err)
+    process.exit()
+  })

--- a/script/resize.js
+++ b/script/resize.js
@@ -7,15 +7,20 @@ const icons = recursiveReadSync(path.join(__dirname, '../apps'))
 
 console.log(`Resizing ${icons.length} icons...`)
 
-function resize (icon, size) {
-  const newFile = icon.replace('.png', `-${size}.png`)
-  return sharp(fs.readFileSync(icon))
+function resize (file, size) {
+  const newFile = file.replace('.png', `-${size}.png`)
+
+  if (fs.existsSync(newFile) && fs.statSync(newFile).mtime > fs.statSync(file).mtime) {
+    console.log(`${path.basename(newFile)} exists and is newer than original; skipping`)
+  }
+
+  return sharp(fs.readFileSync(file))
     .resize(size, size)
     .max()
     .toFormat('png')
     .toFile(newFile)
     .then(() => {
-      console.log(newFile)
+      console.log(path.basename(newFile))
     })
 }
 

--- a/script/resize.js
+++ b/script/resize.js
@@ -11,7 +11,8 @@ function resize (file, size) {
   const newFile = file.replace('.png', `-${size}.png`)
 
   if (fs.existsSync(newFile) && fs.statSync(newFile).mtime > fs.statSync(file).mtime) {
-    console.log(`${path.basename(newFile)} exists and is newer than original; skipping`)
+    console.log(`${path.basename(newFile)} (exists and is up to date; skipping)`)
+    return Promise.resolve(null)
   }
 
   return sharp(fs.readFileSync(file))

--- a/test/data.js
+++ b/test/data.js
@@ -75,6 +75,13 @@ describe('app data', () => {
           const dimensions = imageSize(iconPath)
           expect(dimensions.width).to.be.above(127)
         })
+
+        it('is not more than 1024px x 1024px', function () {
+          if (!pathExists(iconPath)) return this.skip()
+
+          const dimensions = imageSize(iconPath)
+          expect(dimensions.width).to.be.below(1025)
+        })
       })
     })
   })

--- a/test/data.js
+++ b/test/data.js
@@ -69,11 +69,11 @@ describe('app data', () => {
           expect(dimensions.width).to.equal(dimensions.height)
         })
 
-        it('is at least 100px x 100px', function () {
+        it('is at least 128px x 128px', function () {
           if (!pathExists(iconPath)) return this.skip()
 
           const dimensions = imageSize(iconPath)
-          expect(dimensions.width).to.be.above(99)
+          expect(dimensions.width).to.be.above(127)
         })
       })
     })


### PR DESCRIPTION
## Problem

There are 6.5 MB worth of icons on [electron.atom.io/apps/](http://electron.atom.io/apps)

## Solution

This PR adds a script that resizes all the app icons to various smaller dimensions: 32, 64, 128.

To keep the repo small and free of auto-generated content, this new resize script is run in an npm postinstall hook:

```
$ npm install electron/electron-apps

$ tree node_modules/electron-apps/apps     
node_modules/electron-apps/apps
├── 1clipboard
│   ├── 1clipboard-icon-128.png
│   ├── 1clipboard-icon-32.png
│   ├── 1clipboard-icon-64.png
│   ├── 1clipboard-icon.png
│   └── 1clipboard.yml
...
```

We can shave off 5 MB by using the 64x64 images on the apps page:

```
❯ du -hc apps/**/*icon.png | grep total
6.5M	total

❯ du -hc apps/**/*64.png | grep total
1.5M	total
```

Even if we use 128px icons we can shave off 3.4 MB:

```
du -hc apps/**/*128.png | grep total
3.1M	total
```

## Notes

I initially tried this with [jimp](https://github.com/oliver-moran/jimp) but it couldn't handle all the images. Now using [sharp](http://sharp.dimens.io/en/stable/api-resize/) which introduces a native dependency, but it's fast and seems to work well for all the existing 250-ish icons.

cc @electron/maintainers 