### PR TITLE
disable apps using company logos without permission

### DIFF
--- a/apps/caprine/caprine.yml
+++ b/apps/caprine/caprine.yml
@@ -8,3 +8,4 @@ keywords:
     - social
     - facebook
 license: MIT
+disabled: true

--- a/apps/papyrus/papyrus.yml
+++ b/apps/papyrus/papyrus.yml
@@ -8,3 +8,4 @@ keywords:
     - notes
     - 'file sharing'
 license: MIT
+disabled: true

--- a/apps/ramme/ramme.yml
+++ b/apps/ramme/ramme.yml
@@ -8,3 +8,4 @@ keywords:
     - social
     - instagram
 license: MIT
+disabled: true

--- a/apps/slack-catchup/slack-catchup.yml
+++ b/apps/slack-catchup/slack-catchup.yml
@@ -1,3 +1,4 @@
 name: 'Slack Catchup'
 description: 'Catch up all the unread across your Slack teams in a single place'
 website: 'https://slackcatchup.com'
+disabled: true

--- a/apps/youtube-mp3/youtube-mp3.yml
+++ b/apps/youtube-mp3/youtube-mp3.yml
@@ -1,3 +1,4 @@
 name: Youtube-mp3
 description: 'Convert a youtube video to mp3 and download it'
 website: 'https://github.com/MedZed/Electron-Youtube-to-Mp3-Converter'
+disabled: true


### PR DESCRIPTION
I have consulted with our legal team, and they have advised us to disallow apps that are using the names of other companies or icons that we find too similar to the logos of other companies without verifying their permission to do so.

That said, we would love to continue featuring all of these apps on our site. If you are an author of one of these apps and would like to see it on the site again, please open a PR that updates the icon file and removes the `disabled: true` line from the app's yml file.

Apologies for the inconvenience, and thanks for your understanding.

cc @terkelg @sindresorhus @MedZed @morkro

