### PR TITLE
Rename author name to project name

### DIFF
--- a/apps/jukeboks/jukeboks.yml
+++ b/apps/jukeboks/jukeboks.yml
@@ -1,4 +1,4 @@
-name: Hirohisa
+name: Jukeboks
 description: 'Fast viewer'
 website: 'https://github.com/hirohisa/Jukeboks'
 repository: 'https://github.com/hirohisa/Jukeboks'


### PR DESCRIPTION
Hi, @zeke. I'm sorry, I mistake to write name  space as author name.

I rename project name