### PR TITLE
do not log every resized filename

### DIFF
--- a/script/resize.js
+++ b/script/resize.js
@@ -5,13 +5,13 @@ const recursiveReadSync = require('recursive-readdir-sync')
 const icons = recursiveReadSync(path.join(__dirname, '../apps'))
   .filter(file => file.match(/icon\.png/))
 
-console.log(`Resizing ${icons.length} icons...`)
+process.stdout.write(`Resizing ${icons.length} icons...`)
 
 function resize (file, size) {
   const newFile = file.replace('.png', `-${size}.png`)
 
+  // skip files that are up to date
   if (fs.existsSync(newFile) && fs.statSync(newFile).mtime > fs.statSync(file).mtime) {
-    console.log(`${path.basename(newFile)} (exists and is up to date; skipping)`)
     return Promise.resolve(null)
   }
 
@@ -20,9 +20,6 @@ function resize (file, size) {
     .max()
     .toFormat('png')
     .toFile(newFile)
-    .then(() => {
-      console.log(path.basename(newFile))
-    })
 }
 
 const resizes = icons.map(icon => resize(icon, 32))
@@ -31,11 +28,11 @@ const resizes = icons.map(icon => resize(icon, 32))
 
 Promise.all(resizes)
   .then(function (results) {
-    console.log(`Done resizing ${icons.length} icons`)
+    process.stdout.write(` Done.`)
     process.exit()
   })
   .catch(function (err) {
-    console.error('Problem resizing icons')
+    console.error('Error resizing icons!')
     console.error(err)
     process.exit()
   })


### PR DESCRIPTION
🔕

278 icons * 3 resizes each == too much output.

```
ionic-lab-icon-64.png
jasper-icon-64.png
jukeboks-icon-64.png
jibo-icon-64.png
kaku-icon-64.png
kakapo-icon-64.png
kap-icon-64.png
kongdash-icon-64.png
keeweb-icon-64.png
kitematic-icon-64.png
laverna-icon-64.png
ling-icon-64.png
light-table-icon-64.png
lightgallery-icon-64.png
losslesscut-icon-64.png
makeappicon-desktop-icon-64.png
manageyum-icon-64.png
mapbox-icon-64.png
mancy-icon-64.png
markdownify-icon-64.png
marp-icon-64.png
mdnote-icon-64.png
medley-icon-64.png
mattermost-icon-64.png
```