### PR TITLE
distinguish human tests from bot tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build:resize": "node script/resize.js",
     "build:dates": "node script/dates",
     "build:pack": "node script/pack.js",
-    "test": "mocha",
+    "test": "mocha test/human-data.js",
+    "test-all": "mocha",
     "wizard": "node wizard.js",
     "release": "scripts/release.sh"
   },

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,7 +9,7 @@ git clone https://github.com/electron/electron-apps app
 cd app
 npm install
 npm run build
-npm test
+npm run test-all
 [[ `git status --porcelain` ]] || exit
 git add .
 git config user.email "kevinsawicki+electron-bot@github.com"

--- a/test/human-data.js
+++ b/test/human-data.js
@@ -12,7 +12,7 @@ const slugs = fs.readdirSync(path.join(__dirname, '../apps'))
     return fs.statSync(path.join(__dirname, `../apps/${filename}`)).isDirectory()
   })
 
-describe('app data', () => {
+describe('human-submitted app data', () => {
   it('includes lots of apps', () => {
     expect(slugs.length).to.be.above(200)
   })

--- a/test/machine-data.js
+++ b/test/machine-data.js
@@ -3,7 +3,7 @@ const path = require('path')
 const apps = require('..')
 const expect = require('chai').expect
 
-describe('index.json build artifact', () => {
+describe('machine-generated app data', () => {
 
   it('is an array', () => {
     expect(apps).to.be.an('array')


### PR DESCRIPTION
Basic app info is added by **humans**, and extra info is later filled in by a **bot**.

Humans edit the contents of the `/apps` directory, adding basic data
and an icon for each app. When a pull request is opened on this repo, the CI
service tests that the data in the `/apps` directory is complete.

A bot periodically clones this repository and does some extra work:

- collecting app submission dates from git history
- resizing icons
- extracting color palettes from icons ([WIP branch](https://github.com/electron/electron-apps/tree/colors))

This PR begins to formally separate those two concerns.