### PR TITLE
add script for cleaning leftover build artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.json",
   "scripts": {
     "build": "npm-run-all build:*",
+    "build:clean": "node script/clean.js",
     "build:resize": "node script/resize.js",
     "build:dates": "node script/dates",
     "build:colors": "node script/colors",
@@ -35,6 +36,7 @@
     "mocha": "^3.2.0",
     "npm-run-all": "^4.0.1",
     "recursive-readdir-sync": "^1.0.6",
+    "rimraf": "^2.6.1",
     "sharp": "^0.17.0",
     "slugg": "^1.1.0",
     "yamljs": "^0.2.8"

--- a/script/clean.js
+++ b/script/clean.js
@@ -1,0 +1,22 @@
+// Clean up any files left behind by removed apps.
+//
+// When someone submits a PR to remove an app, only the `foo.yml` and `foo-icon.png`
+// files are present in the repo. This script cleans up any leftover local
+// artifacts that were created by `npm run build`, such as `apps/foo-icon-128.png`
+
+const fs = require('fs')
+const path = require('path')
+const rimraf = require('rimraf').sync
+
+fs.readdirSync(path.join(__dirname, '../apps'))
+  .filter(filename => {
+    return fs.statSync(path.join(__dirname, `../apps/${filename}`)).isDirectory()
+  })
+  .filter(filename => {
+    return !fs.existsSync(path.join(__dirname, `../apps/${filename}/${filename}.yml`))
+  })
+  .forEach(filename => {
+    const appDir = path.join(__dirname, `../apps/${filename}`)
+    console.log(`Removing leftover artifacts from ${appDir}`)
+    rimraf(appDir)
+  })


### PR DESCRIPTION
`npm run build` wasn't working on machine after some apps were removed. This adds a cleanup step to the build process to ensure removed apps are fully removed.