### PR TITLE
fix broken reference to slug

### DIFF
--- a/script/dates.js
+++ b/script/dates.js
@@ -16,7 +16,7 @@ apps
     cmd = `git log -S "${app.website}" --pretty=format:'%ci' | tail -n1`
     const date = String(execSync(cmd)).slice(0, 10)
     console.log(`${app.slug}: ${date}`)
-    dates[slug] = date
+    dates[app.slug] = date
   })
 
 fs.writeFileSync(datesPath, JSON.stringify(dates, null, 2))


### PR DESCRIPTION
This typo was breaking the build process, but it wasn't picked up by CI.

One of the perils of only using CI to test [human-generated content](https://github.com/electron/electron-apps/blob/aacf8bf73a68a99d74b8b0c8189c9998f7b98257/package.json#L12-L13).

