### PR TITLE
use the right email for electron-bot

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,7 +12,7 @@ npm run build
 npm run test-all
 [[ `git status --porcelain` ]] || exit
 git add .
-git config user.email "kevinsawicki+electron-bot@github.com"
+git config user.email "kevin+electronbot@github.com"
 git config user.name "electron-bot"
 git commit -am "update apps"
 npm version minor -m "bump minor to %s"


### PR DESCRIPTION
New releases are not properly being associated with @electron-bot, presumably because the git configured email address is wrong:

![screen shot 2017-03-31 at 11 09 52 am](https://cloud.githubusercontent.com/assets/2289/24563293/ae879088-1602-11e7-8b2b-125d97c84b40.png)
