### PR TITLE
tweak release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,9 +12,7 @@ npm run build
 npm run test-all
 [[ `git status --porcelain` ]] || exit
 git add .
-git config user.email "kevin+electronbot@github.com"
-git config user.name "electron-bot"
-git commit -am "update apps"
+git commit -am "update apps" --author "Electron Bot <kevin+electronbot@github.com>"
 npm version minor -m "bump minor to %s"
 npm publish
 git push origin master --follow-tags

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,5 +14,5 @@ npm run test-all
 git add .
 git commit -am "update apps" --author "Electron Bot <kevin+electronbot@github.com>"
 npm version minor -m "bump minor to %s"
-npm publish
 git push origin master --follow-tags
+npm publish


### PR DESCRIPTION
Every so often (twice now) the release script will successfully publish a new version to npm, but the following `git push` will fail, leaving github out of sync with npm and preventing new versions from publishing. This PR works around the problem by git pushing first, then npm publishing.

Also, a minor change to the way git author is specified.