### PR TITLE
add tests for screenshot metadata

### DIFF
--- a/test/human-data.js
+++ b/test/human-data.js
@@ -65,6 +65,26 @@ describe('human-submitted app data', () => {
         it('has no empty properties', () => {
           expect(cleanDeep(app)).to.deep.equal(app)
         })
+
+        describe('screenshots', () => {
+          const screenshots = app.screenshots || []
+
+          it('requires imageUrl to be a fully-qualified HTTPS URL', () => {  
+            screenshots.forEach(screenshot => {
+              expect(isUrl(screenshot.imageUrl) && /^https/.test(screenshot.imageUrl)).to.equal(true, 
+                `${app.slug} screenshot imageUrl must be a fully-qualified HTTPS URL`
+              )
+            })
+          })
+
+          it('requires linkUrl to be a fully-qualified URL, if present', () => {  
+            screenshots.forEach(screenshot => {
+              expect(!screenshot.linkUrl || isUrl(screenshot.linkUrl)).to.equal(true, 
+                `${app.slug} screenshot linkURL must be a fully qualified URL`
+              )
+            })
+          })
+        })
       })
 
       describe('icon', () => {


### PR DESCRIPTION
These tests assert that every app (that has screenshots) has valid screenshot metadata, like a fully qualified HTTPS URL for the image, and a fully-qualified URL for the link, if present.

Waiting for Xcode to install, so haven't tested this locally yet. 🤞