### PR TITLE
make release script exit successfully when git is clean

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -10,7 +10,7 @@ cd app
 npm install --quiet
 npm run build
 npm run test-all
-[[ `git status --porcelain` ]] || exit
+[[ `git status --porcelain` ]] || exit 0
 git config user.email "kevin+electronbot@github.com" 
 git config user.name "Electron Bot" 
 git add .


### PR DESCRIPTION
Seeing this in the build script output:

```

++ git status --porcelain
+ [[ -n '' ]]
+ exit
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! electron-apps@1.1648.0 release: `script/release.sh`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the electron-apps@1.1648.0 release script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /app/.npm/_logs/2017-07-21T15_34_58_083Z-debug.log
```

But this is not an error situation. It just means that there's nothing to commit and the release script should just exit. Maybe adding an explicit exit code will solve this.