### PR TITLE
description cannot start with app name

### DIFF
--- a/apps/appear-in/appear-in.yml
+++ b/apps/appear-in/appear-in.yml
@@ -1,11 +1,12 @@
 name: appear.in
-description: 'Unofficial appear.in app.'
+description: 'Unofficial desktop client for appear.in'
 website: 'https://github.com/vitorgalvao/appear.in'
 repository: 'https://github.com/vitorgalvao/appear.in'
 keywords:
     - appear.in
     - chat
     - conference
+    - screensharing
     - video
     - webrtc
 license: Unlicense

--- a/apps/bitbloq/bitbloq.yml
+++ b/apps/bitbloq/bitbloq.yml
@@ -1,5 +1,5 @@
 name: Bitbloq
-description: 'Bitbloq is a tool to help children to learn and create programs for a microcontroller or robot, and to load them easily.'
+description: 'Help children create programs for a microcontroller or robot'
 website: 'http://bitbloq.bq.com'
 repository: 'https://github.com/bq/bitbloq-offline'
 keywords:

--- a/apps/colorpicker/colorpicker.yml
+++ b/apps/colorpicker/colorpicker.yml
@@ -1,5 +1,5 @@
 name: ColorPicker
-description: 'Colorpicker can show colors with hex/rgb code, and generate shading of your color.'
+description: 'Show colors with hex/rgb codes and generate shades'
 website: 'https://crea-th.at/p/colorpicker/'
 repository: 'https://github.com/Toinane/colorpicker'
 keywords:

--- a/apps/criptio/criptio.yml
+++ b/apps/criptio/criptio.yml
@@ -1,7 +1,8 @@
 name: Criptio
-description: 'Criptio is a tool for encrypt and decrypt files.'
+description: 'Encrypt and decrypt files.'
 website: 'https://itunes.apple.com/us/app/criptio/id1102582966?mt=12'
 keywords:
+    - encryption
     - security
     - productivity
 category: Productivity

--- a/apps/egret-wing/egret-wing.yml
+++ b/apps/egret-wing/egret-wing.yml
@@ -1,6 +1,7 @@
 name: 'Egret Wing'
-description: 'Egret Wing'
+description: 'Desktop client for Egret Wing'
 website: 'http://www.egret.com/products-wing'
+disabled: true # site if offline
 locales:
     - zh_CN
 keywords:

--- a/apps/franz/franz.yml
+++ b/apps/franz/franz.yml
@@ -1,5 +1,5 @@
 name: Franz
-description: 'Franz is a messaging app / former emperor of Austria, combining chat &amp; messaging services into one application'
+description: 'Messaging app / former emperor of Austria, combining chat and messaging services into one application'
 website: 'http://meetfranz.com'
 keywords:
     - messaging

--- a/apps/glyphr-studio/glyphr-studio.yml
+++ b/apps/glyphr-studio/glyphr-studio.yml
@@ -1,5 +1,5 @@
 name: 'Glyphr Studio'
-description: 'Glyphr Studio is a free, web based font designer, focusing on font design for hobbyists.'
+description: 'Free font design tool for hobbyists.'
 website: 'https://github.com/glyphr-studio/Glyphr-Studio-Desktop'
 repository: 'https://github.com/glyphr-studio/Glyphr-Studio-Desktop'
 keywords:

--- a/apps/groupme/groupme.yml
+++ b/apps/groupme/groupme.yml
@@ -1,5 +1,5 @@
 name: GroupMe
-description: 'Unofficial GroupMe App'
+description: 'Unofficial desktop client for GroupMe'
 website: 'https://github.com/dcrousso/GroupMe#readme'
 repository: 'https://github.com/dcrousso/GroupMe'
 keywords:

--- a/apps/headlines/headlines.yml
+++ b/apps/headlines/headlines.yml
@@ -1,5 +1,5 @@
 name: Headlines
-description: 'View latest news headlines with categories'
+description: 'View the latest news headlines with categories'
 website: 'https://github.com/MedZed/Electron-Headlines'
 keywords:
     - news

--- a/apps/now/now.yml
+++ b/apps/now/now.yml
@@ -1,5 +1,5 @@
 name: Now
-description: 'The desktop client for ZEIT''s now'
+description: 'The desktop client for ZEIT''s now.sh platform'
 website: 'https://zeit.co/app'
 repository: 'https://github.com/zeit/now-app'
 keywords:

--- a/apps/paws-for-trello/paws-for-trello.yml
+++ b/apps/paws-for-trello/paws-for-trello.yml
@@ -1,5 +1,5 @@
 name: 'Paws for Trello'
-description: 'Paws for Trello is a beautiful Trello client for Mac and Windows. It brings Trello to your desktop with native notifications, powerful shortcuts and more - away from the distractions of your browser.'
+description: 'Unofficial Trello client with native notifications, shortcuts, and more.'
 website: 'http://friendlyfox.es/pawsfortrello/'
 keywords:
     - trello

--- a/apps/pencil/pencil.yml
+++ b/apps/pencil/pencil.yml
@@ -1,5 +1,5 @@
 name: Pencil
-description: 'The Pencil Project''s unique mission is to build a free and opensource tool for making diagrams and GUI prototyping that everyone can use'
+description: 'A free and open-source tool for making diagrams and GUI prototyping'
 website: 'http://pencil.evolus.vn'
 repository: 'https://github.com/evolus/pencil'
 keywords:

--- a/apps/preserver/preserver.yml
+++ b/apps/preserver/preserver.yml
@@ -1,5 +1,5 @@
 name: Preserver
-description: 'Preserver is an notes organizer desktop app'
+description: 'Notes organizer'
 website: 'https://github.com/hsbalar/Preserver'
 keywords:
     - notes

--- a/apps/qmui-web/qmui-web.yml
+++ b/apps/qmui-web/qmui-web.yml
@@ -1,5 +1,5 @@
 name: 'QMUI Web'
-description: 'QMUI Web Desktop is an application for managing projects based on QMUI Web Framework.'
+description: 'Manage projects based on QMUI Web Framework.'
 website: 'http://qmuiteam.com/web'
 repository: 'https://github.com/QMUI/qmui_web_desktop'
 keywords:

--- a/apps/socialcast/socialcast.yml
+++ b/apps/socialcast/socialcast.yml
@@ -1,5 +1,5 @@
 name: Socialcast
-description: 'Socialcast is an enterprise social network platform'
+description: 'Enterprise social network platform.'
 website: 'http://socialcast.com/'
 keywords:
     - enterprise

--- a/apps/soundnode/soundnode.yml
+++ b/apps/soundnode/soundnode.yml
@@ -1,5 +1,5 @@
 name: Soundnode
-description: 'Soundnode App is the Soundcloud for desktop.'
+description: 'Unofficial desktop client for Soundcloud.'
 website: 'http://www.soundnodeapp.com'
 repository: 'https://github.com/Soundnode/soundnode-app'
 keywords:

--- a/apps/timetable/timetable.yml
+++ b/apps/timetable/timetable.yml
@@ -1,5 +1,5 @@
 name: TimeTable
-description: 'TimeTable in your menubar!'
+description: 'A time table in your menubar!'
 website: 'https://github.com/willyb321/electron-menubar-timetable'
 repository: 'https://github.com/willyb321/electron-menubar-timetable'
 keywords:

--- a/apps/vagrant-manager/vagrant-manager.yml
+++ b/apps/vagrant-manager/vagrant-manager.yml
@@ -1,5 +1,5 @@
 name: 'Vagrant Manager'
-description: 'Vagrant Manager is an status bar menu app that lets you manage all of your vagrant machines from one central location.'
+description: 'Menu bar app for managing your vagrant machines.'
 website: 'https://github.com/vaibhav-sidapara/vagrant-manager'
 repository: 'https://github.com/vaibhav-sidapara/vagrant-manager'
 keywords:

--- a/apps/yout/yout.yml
+++ b/apps/yout/yout.yml
@@ -1,5 +1,5 @@
 name: Yout
-description: 'Yout Player is the new way to watch your playlists from youtube on desktop.'
+description: 'The new way to watch your playlists from YouTube on desktop.'
 website: 'https://youtplayer.github.io/'
 keywords:
     - yout

--- a/test/human-data.js
+++ b/test/human-data.js
@@ -46,8 +46,8 @@ describe('human-submitted app data', () => {
           expect(app.description.length).to.be.above(0)
         })
 
-        it('does not start description with app name', () => {
-          expect(app.description.toLowerCase().split(' ')[0]).to.not.equal(app.name.toLowerCase())
+        it('should not start description with app name', () => {
+          expect(app.description.toLowerCase().indexOf(app.name.toLowerCase())).to.not.equal(0)
         })
 
         it('has a website with a valid URL', () => {

--- a/test/human-data.js
+++ b/test/human-data.js
@@ -46,6 +46,10 @@ describe('human-submitted app data', () => {
           expect(app.description.length).to.be.above(0)
         })
 
+        it('does not start description with app name', () => {
+          expect(app.description.toLowerCase().split(' ')[0]).to.not.equal(app.name.toLowerCase())
+        })
+
         it('has a website with a valid URL', () => {
           expect(isUrl(app.website)).to.equal(true)
         })


### PR DESCRIPTION
This PR adds a test that verifies that app descriptions don't start with the name of the app itself. This works for single-word as well as multi-word app names.

It also cleans up all existing apps that were in violation of that rule. :)