### PR TITLE
test that keywords is an array if present

### DIFF
--- a/test/human-data.js
+++ b/test/human-data.js
@@ -58,6 +58,10 @@ describe('human-submitted app data', () => {
           expect(!app.repository || isUrl(app.repository)).to.equal(true)
         })
 
+        it('has an array of keywords, or none at all', () => {
+          expect(!app.keywords || Array.isArray(app.keywords)).to.eq(true)
+        })
+
         it('has a category', () => {
           expect(app.category.length).to.be.above(0)
         })


### PR DESCRIPTION
Just got a PR that has `keywords` as a string instead of an array: https://github.com/electron/electron-apps/pull/243

This PR adds a test to check that `keywords` is an array, if it exists.