### PR TITLE
set app submission date to today

### DIFF
--- a/script/dates.js
+++ b/script/dates.js
@@ -11,9 +11,7 @@ console.log('Checking app submission dates...')
 apps
   .filter(app => existingSlugs.indexOf(app.slug) === -1)
   .forEach(app => {
-    // https://git-scm.com/docs/pretty-formats
-    const cmd = `git log -S "${app.website}" --pretty=format:'%ci' | tail -n1`
-    const date = String(execSync(cmd)).slice(0, 10)
+    const date = new Date().toISOString().slice(0,10)
     console.log(`${app.slug}: ${date}`)
     dates[app.slug] = date
   })


### PR DESCRIPTION
I noticed that the build+release process slowed down considerably because of the code that was looking through the (large) git history to find app submission dates. Now that we are caught up on dates and no longer applying them retroactively to apps submitted in the past, we can always just apply the current day as the date. This should speed things up again. 🚀 