### PR TITLE
Add Homebrew Cask Names

### DIFF
--- a/apps/atom/atom.yml
+++ b/apps/atom/atom.yml
@@ -2,6 +2,7 @@ name: Atom
 description: 'A hackable text editor for the 21st Century'
 website: 'https://atom.io'
 repository: 'https://github.com/atom/atom'
+homebrewCaskName: atom
 keywords:
     - 'web development'
     - writing

--- a/apps/figma/figma.yml
+++ b/apps/figma/figma.yml
@@ -1,6 +1,7 @@
 name: Figma
 description: 'The collaborative interface design tool.'
 website: 'https://www.figma.com/'
+homebrewCaskName: figma
 keywords:
     - graphics
     - images

--- a/apps/github-desktop/github-desktop.yml
+++ b/apps/github-desktop/github-desktop.yml
@@ -2,6 +2,7 @@ name: 'GitHub Desktop'
 description: 'Simple collaboration from your desktop'
 website: 'https://desktop.github.com'
 repository: 'https://github.com/desktop/desktop'
+homebrewCaskName: github-desktop
 keywords:
     - git
     - github

--- a/apps/hyper/hyper.yml
+++ b/apps/hyper/hyper.yml
@@ -2,6 +2,7 @@ name: Hyper
 description: 'HTML/JS/CSS Terminal'
 website: 'https://hyper.is'
 repository: 'https://github.com/zeit/hyper'
+homebrewCaskName: hyper
 keywords:
     - terminal
     - html

--- a/apps/simplenote/simplenote.yml
+++ b/apps/simplenote/simplenote.yml
@@ -2,6 +2,7 @@ name: Simplenote
 description: 'An easy way to keep notes, lists, ideas and more.'
 website: 'https://simplenote.com'
 repository: 'https://github.com/Automattic/simplenote-electron'
+homebrewCaskName: simplenote
 keywords:
     - notes
     - utility

--- a/apps/slack/slack.yml
+++ b/apps/slack/slack.yml
@@ -1,6 +1,13 @@
 name: Slack
 description: 'A messaging app for teams'
 website: 'https://slack.com'
+homebrewCaskName: slack
 keywords:
     - messaging
+    - chat
+    - p2p
+    - video
+    - voip
+    - phone
+    - community
 category: 'Social Networking'

--- a/apps/visual-studio-code/visual-studio-code.yml
+++ b/apps/visual-studio-code/visual-studio-code.yml
@@ -1,6 +1,7 @@
 name: 'Visual Studio Code'
 description: 'Open source code editor developed by Microsoft'
 website: 'https://code.visualstudio.com'
+homebrewCaskName: visual-studio-code
 license: MIT
 keywords:
     - code

--- a/apps/webtorrent/webtorrent.yml
+++ b/apps/webtorrent/webtorrent.yml
@@ -1,6 +1,7 @@
 name: WebTorrent
 description: 'The streaming torrent client'
 website: 'https://webtorrent.io/desktop'
+homebrewCaskName: webtorrent
 keywords:
     - torrent
 category: Utilities

--- a/contributing.md
+++ b/contributing.md
@@ -53,6 +53,7 @@ apps
 - `repository` is optional, but must be a fully-qualified URL if provided.
 - `keywords` is optional, but should be an array if provided.
 - `license` is optional.
+- `homebrewCaskName` can be specified if you app is on [homebrew cask](https://caskroom.github.io).
 - `youtube_video_url` is optional, but must be a fully-qualified URL if provided.
 - No fields should be left blank.
 


### PR DESCRIPTION
Many Electron apps are published to homebrew so macOS users can install them on the command line like `brew cask install hyper`. Let's display these on the website!