### PR TITLE
add webtorrent repository url

### DIFF
--- a/apps/webtorrent/webtorrent.yml
+++ b/apps/webtorrent/webtorrent.yml
@@ -1,6 +1,7 @@
 name: WebTorrent
-description: 'The streaming torrent client'
-website: 'https://webtorrent.io/desktop'
+description: The streaming torrent client
+website: https://webtorrent.io/desktop
+repository: https://github.com/webtorrent/webtorrent
 homebrewCaskName: webtorrent
 keywords:
     - torrent


### PR DESCRIPTION
This will make Webtorrent download links, release notes, and other goodies show up on https://electronjs.org/apps/webtorrent

cc @feross 