### PR TITLE
avoid redundant website and repo urls

### DIFF
--- a/script/pack.js
+++ b/script/pack.js
@@ -5,6 +5,7 @@ const dates = require('../meta/dates.json')
 const colors = require('../meta/colors.json')
 const releases = require('../meta/releases.json')
 const readmes = require('../meta/readmes.json')
+const parseGitHubUrl = require('github-url-to-object')
 const apps = []
 
 fs.readdirSync(path.join(__dirname, '../apps'))
@@ -31,6 +32,13 @@ fs.readdirSync(path.join(__dirname, '../apps'))
   app.goodColorOnWhite = app.goodColorOnWhite || colors[slug].goodColorOnWhite
   app.goodColorOnBlack = app.goodColorOnBlack || colors[slug].goodColorOnBlack
   app.faintColorOnWhite = app.faintColorOnWhite || colors[slug].faintColorOnWhite
+
+  // Delete website if it's the same URL as repository
+  const parsedWebsite = parseGitHubUrl(app.website)
+  const parsedRepo = parseGitHubUrl(app.repository)
+  if (parsedWebsite && parsedRepo && parsedWebsite.https_url === parsedRepo.https_url) {
+    delete app.website
+  }
 
   apps.push(app)
 })

--- a/test/human-data.js
+++ b/test/human-data.js
@@ -51,8 +51,8 @@ describe('human-submitted app data', () => {
           expect(app.description.toLowerCase().indexOf(app.name.toLowerCase())).to.not.equal(0)
         })
 
-        it('has a website with a valid URL', () => {
-          expect(isUrl(app.website)).to.equal(true)
+        it('has a website with a valid URL (or no website)', () => {
+          expect(!app.website || isUrl(app.website)).to.equal(true)
         })
 
         it('has a valid repository URL (or no repository)', () => {


### PR DESCRIPTION
If an app has a `website` and a `repository` and they're both effectively the same URL, then `website` is removed (in the published module).

Fixes #367 