### PR TITLE
Put Discord in Social Networking

### DIFF
--- a/apps/discord/discord.yml
+++ b/apps/discord/discord.yml
@@ -2,5 +2,5 @@ name: Discord
 description: 'All-in-one voice and text chat for gamers'
 website: 'http://discordapp.com'
 keywords:
-    - games
-category: Games
+    - chat
+category: 'Social Networking'


### PR DESCRIPTION
I believe Discord belongs in 'Social Networking' because it is technically a social network for gaming, not a game itself.

<!--
Thanks for submitting your app!

Please be sure you're following the guidelines at 
https://github.com/electron/electron-apps/blob/master/contributing.md

To make it easier for folks to review your submission, please 
include screenshots and URLs in the body of the pull request.
-->