### PR TITLE
Fix webtorrent-desktop repository url

### DIFF
--- a/apps/webtorrent/webtorrent.yml
+++ b/apps/webtorrent/webtorrent.yml
@@ -1,7 +1,7 @@
 name: WebTorrent
 description: The streaming torrent client
 website: https://webtorrent.io/desktop
-repository: https://github.com/webtorrent/webtorrent
+repository: https://github.com/webtorrent/webtorrent-desktop
 homebrewCaskName: webtorrent
 keywords:
     - torrent


### PR DESCRIPTION
Just a small fix of Webtorrent desktop's repository url.